### PR TITLE
Add ON_GLOBAL_NICE_CALL macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ TEST(TestGlobal, CanMultiplyGlobal)
 }
 ```
 
-Also you can use `ON_GLOBAL_CALL` to specify default behavior. 
+Also you can use `ON_GLOBAL_CALL` to specify default behavior. `ON_GLOBAL_NICE_CALL` can be used to set default behavior with suppressed warning when this mock was actually called.
 
 [gmock-global](https://github.com/apriorit/gmock-global) supports more than 10 arguments with [gtest version 1.8.1](https://github.com/google/googletest/releases/tag/release-1.8.1). But it requires [gmock-more-args version 1.0.1](https://github.com/apriorit/gmock-more-args/releases/tag/1.0.1) in case you use [gtest version 1.8.0](https://github.com/google/googletest/releases/tag/release-1.8.0)
 

--- a/include/gmock-global/gmock-global.h
+++ b/include/gmock-global/gmock-global.h
@@ -930,10 +930,14 @@ private:
 #define GLOBAL_MOCK_TYPE(name)              gmock_globalmock_##name
 #define GLOBAL_MOCK_INSTANCE(name)          gmock_globalmock_##name##_instance
 
-#define GLOBAL_MOCK_CALL(name, method, callType) \
+#define GLOBAL_MOCK_INTERNAL_CALL(name, method, callType, mockType) \
 GlobalMockDeleter<GLOBAL_MOCK_TYPE(name)> GLOBAL_MOCK_DELETER_NAME(mock_deleter)(GLOBAL_MOCK_INSTANCE(name));\
-if (!GLOBAL_MOCK_INSTANCE(name) || 0 != strcmp(GLOBAL_MOCK_INSTANCE(name)->m_tag, __FUNCTION__)) GLOBAL_MOCK_INSTANCE(name).reset(new GLOBAL_MOCK_TYPE(name)(__FUNCTION__));\
+if (!GLOBAL_MOCK_INSTANCE(name) || 0 != strcmp(GLOBAL_MOCK_INSTANCE(name)->m_tag, __FUNCTION__)) GLOBAL_MOCK_INSTANCE(name).reset(new mockType(__FUNCTION__));\
 callType(*GLOBAL_MOCK_INSTANCE(name), method)
+
+#define GLOBAL_MOCK_CALL(name, method, callType)      GLOBAL_MOCK_INTERNAL_CALL(name, method, callType, GLOBAL_MOCK_TYPE(name))
+#define GLOBAL_NICE_MOCK_CALL(name, method, callType) GLOBAL_MOCK_INTERNAL_CALL(name, method, callType, ::testing::NiceMock<GLOBAL_MOCK_TYPE(name)>)
 
 #define EXPECT_GLOBAL_CALL(name, method)    GLOBAL_MOCK_CALL(name, method, EXPECT_CALL)
 #define ON_GLOBAL_CALL(name, method)        GLOBAL_MOCK_CALL(name, method, ON_CALL)
+#define ON_GLOBAL_NICE_CALL(name, method)   GLOBAL_NICE_MOCK_CALL(name, method, ON_CALL)


### PR DESCRIPTION
`ON_GLOBAL_CALL` can be used to set default behavior. However, when such a mock is called, it produces a warning, cluttering the test output that uninteresting calls were performed. Such warnings can be useful in some situation, however, in many cases we can safely suppress them.

`gmock-global` missed a way to control those warnings, and `ON_GLOBAL_NICE_CALL` should resolve this issue.

For additional information pls see [gmock cook book](https://github.com/google/googletest/blob/main/docs/gmock_cook_book.md#understanding-uninteresting-vs-unexpected-calls-uninteresting-vs-unexpected)